### PR TITLE
Fixing license metadata from file-link to SPDX id

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.2.2"
 description = "Visualization of Pytorch Models"
 readme = "README.md"
 requires-python = ">=3.7"
-license = {file = "LICENSE"}
+license = "MIT"
 keywords = [
     "pytorch", "visualization", "keras",
     "torch", "deep learning", "machine learning",


### PR DESCRIPTION
Proposal to fix #57 - my understanding is that the file linking is used for proprietary licensing rather than open source.