### PR TITLE
Use versioning based on commit hash for actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,9 @@ jobs:
     needs: tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up Python 3.13
-        uses: actions/setup-python@v4.3.0
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
           python-version: 3.13
 

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -13,12 +13,12 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: true
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
           python-version: 3.12
 
@@ -33,6 +33,6 @@ jobs:
       - name: "Build docs"
         run: mkdocs build -f mkdocs.yml
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: JamesIves/github-pages-deploy-action@6c2d9db40f9296374acc17b90404b6e8864128c8 # 4.7.3
         with:
           folder: ./site

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,4 +128,4 @@ jobs:
       run: |
         python -m pytest --no-output
     - name: codecov
-      uses: codecov/codecov-action@v3.1.1
+      uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d # 5.4.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,10 @@ jobs:
       ID_LIST: ${{ steps.configure.outputs.ID_LIST }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           version: "latest"
           python-version: 3.12
@@ -33,7 +33,7 @@ jobs:
       #   # this install python globally
       #   run: uv python install --preview
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
           python-version: 3.12
 
@@ -52,7 +52,7 @@ jobs:
         os: [ubuntu-latest]
         id-number: ${{fromJson(needs.configure.outputs.ID_LIST)}}
     steps:
-    - uses: actions/checkout@v3.1.0
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up version variables
       id: set-version
       run: |
@@ -90,7 +90,7 @@ jobs:
         echo "::endgroup::"
       shell: bash
     - name: Install the latest version of uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
       with:
         version: "latest"
         python-version: ${{ steps.set-version.outputs.PYTHON_VERSION }}
@@ -99,7 +99,7 @@ jobs:
     # - name: Set up Python
     #   run: uv python install --preview
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
       with:
         python-version: ${{ steps.set-version.outputs.PYTHON_VERSION }}
 


### PR DESCRIPTION
This is more secure and reproducible as it prevents updating to new version (silently) despite it might include nefarious code.